### PR TITLE
Follow rust idioms and re-format to standards

### DIFF
--- a/src/bin/asm.rs
+++ b/src/bin/asm.rs
@@ -1,8 +1,7 @@
-
 use std::env;
-use std::io;
 use std::fs::File;
-use std::io::{BufReader, BufRead, Write};
+use std::io;
+use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use std::str::FromStr;
 
@@ -16,7 +15,7 @@ fn parse_numeric(s: &str) -> Result<u8, String> {
     let (num, radix) = match fst {
         '$' => (&s[1..], 16),
         '%' => (&s[1..], 2),
-        _ => (s, 10)
+        _ => (s, 10),
     };
     u8::from_str_radix(num, radix).map_err(|x| format!("{}", x))
 }
@@ -43,30 +42,30 @@ fn handle_line(parts: Vec<&str>) -> Result<Instruction, String> {
         OpCode::Push => {
             assert_length(&parts, 2)?;
             Ok(Instruction::Push(parse_numeric(parts[1])?))
-        },
+        }
         OpCode::AddStack => {
             assert_length(&parts, 1)?;
             Ok(Instruction::AddStack)
-        },
+        }
         OpCode::AddRegister => {
             assert_length(&parts, 3)?;
             Ok(Instruction::AddRegister(
-                    parse_register(parts[1])?,
-                    parse_register(parts[2])?
-                ))
+                parse_register(parts[1])?,
+                parse_register(parts[2])?,
+            ))
         }
         OpCode::PopRegister => {
             assert_length(&parts, 2)?;
             Ok(Instruction::PopRegister(parse_register(parts[1])?))
-        },
+        }
         OpCode::PushRegister => {
             assert_length(&parts, 2)?;
             Ok(Instruction::PushRegister(parse_register(parts[1])?))
-        },
+        }
         OpCode::Signal => {
             assert_length(&parts, 2)?;
             Ok(Instruction::Signal(parse_numeric(parts[1])?))
-        },
+        }
     }
 }
 
@@ -103,8 +102,8 @@ fn main() -> Result<(), String> {
         let instruction = handle_line(parts)?;
         let raw_instruction: u16 = instruction.encode_u16();
         // assumption: >>8 needs to mask for u16
-        output.push((raw_instruction&0xff) as u8);
-        output.push((raw_instruction>>8) as u8);
+        output.push((raw_instruction & 0xff) as u8);
+        output.push((raw_instruction >> 8) as u8);
     }
     let mut stdout = io::stdout().lock();
     stdout.write_all(&output).map_err(|x| format!("{}", x))?;

--- a/src/bin/asm.rs
+++ b/src/bin/asm.rs
@@ -9,16 +9,16 @@ use std::str::FromStr;
 use simplevm::{Instruction, OpCode, Register};
 
 fn parse_numeric(s: &str) -> Result<u8, String> {
-    if s.len() == 0 {
+    if s.is_empty() {
         return Err("string has no length".to_string());
     }
-    let fst = s.chars().nth(0).unwrap();
+    let fst = s.chars().next().unwrap();
     let (num, radix) = match fst {
         '$' => (&s[1..], 16),
         '%' => (&s[1..], 2),
         _ => (s, 10)
     };
-    u8::from_str_radix(num, radix).map_err(|x| format!("{}", x))  
+    u8::from_str_radix(num, radix).map_err(|x| format!("{}", x))
 }
 
 fn parse_register(s: &str) -> Result<Register, String> {
@@ -90,14 +90,14 @@ fn main() -> Result<(), String> {
      */
     for line in BufReader::new(file).lines() {
         let line_inner = line.map_err(|_x| "foo")?;
-        if line_inner.len() == 0 {
+        if line_inner.is_empty() {
             continue;
         }
-        if line_inner.chars().nth(0).unwrap() == ';' {
+        if line_inner.starts_with(';') {
             continue;
         }
-        let parts: Vec<_> = line_inner.split(" ").filter(|x| x.len() > 0).collect();
-        if parts.len() == 0 {
+        let parts: Vec<_> = line_inner.split(' ').filter(|x| !x.is_empty()).collect();
+        if parts.is_empty() {
             continue;
         }
         let instruction = handle_line(parts)?; 

--- a/src/bin/asm.rs
+++ b/src/bin/asm.rs
@@ -71,7 +71,7 @@ fn handle_line(parts: Vec<&str>) -> Result<Instruction, String> {
 }
 
 fn main() -> Result<(), String> {
-    // ./asm file.asm 
+    // ./asm file.asm
 
     let args: Vec<_> = env::args().collect();
     if args.len() != 2 {
@@ -100,7 +100,7 @@ fn main() -> Result<(), String> {
         if parts.is_empty() {
             continue;
         }
-        let instruction = handle_line(parts)?; 
+        let instruction = handle_line(parts)?;
         let raw_instruction: u16 = instruction.encode_u16();
         // assumption: >>8 needs to mask for u16
         output.push((raw_instruction&0xff) as u8);
@@ -109,4 +109,4 @@ fn main() -> Result<(), String> {
     let mut stdout = io::stdout().lock();
     stdout.write_all(&output).map_err(|x| format!("{}", x))?;
     Ok(())
-} 
+}

--- a/src/bin/vm.rs
+++ b/src/bin/vm.rs
@@ -1,7 +1,7 @@
 use std::env;
+use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::Path;
-use std::fs::File;
 
 use simplevm::{Machine, Register};
 
@@ -11,7 +11,6 @@ fn signal_halt(vm: &mut Machine) -> Result<(), String> {
 }
 
 pub fn main() -> Result<(), String> {
-
     let args: Vec<_> = env::args().collect();
     if args.len() != 2 {
         panic!("usage: {} <input>", args[0]);
@@ -21,7 +20,9 @@ pub fn main() -> Result<(), String> {
 
     let mut reader = BufReader::new(file);
     let mut program: Vec<u8> = Vec::new();
-    reader.read_to_end(&mut program).map_err(|x| format!("read: {}", x))?;
+    reader
+        .read_to_end(&mut program)
+        .map_err(|x| format!("read: {}", x))?;
 
     let mut vm = Machine::new();
     vm.set_register(Register::SP, 0x1000);
@@ -34,4 +35,3 @@ pub fn main() -> Result<(), String> {
     println!("A = {}", vm.get_register(Register::A));
     Ok(())
 }
-

--- a/src/bin/vm.rs
+++ b/src/bin/vm.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use simplevm::{Machine, Register};
 
 fn signal_halt(vm: &mut Machine) -> Result<(), String> {
-    vm.halt = true; 
+    vm.halt = true;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
-
-pub mod vm;
 pub mod memory;
-pub mod register;
 pub mod op;
+pub mod register;
+pub mod vm;
 
-pub use crate::vm::*;
-pub use crate::register::*;
 pub use crate::op::*;
+pub use crate::register::*;
+pub use crate::vm::*;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,12 +1,10 @@
-
 pub trait Addressable {
     fn read(&self, addr: u16) -> Option<u8>;
     fn write(&mut self, addr: u16, value: u8) -> bool;
 
-
     fn read2(&self, addr: u16) -> Option<u16> {
         if let Some(x0) = self.read(addr) {
-            if let Some(x1) = self.read(addr+1) {
+            if let Some(x1) = self.read(addr + 1) {
                 return Some((x0 as u16) | ((x1 as u16) << 8));
             }
         };
@@ -16,28 +14,28 @@ pub trait Addressable {
     fn write2(&mut self, addr: u16, value: u16) -> bool {
         let lower = value & 0xff;
         let upper = (value & 0xff00) >> 8;
-        self.write(addr, lower as u8) && self.write(addr+1, upper as u8)
+        self.write(addr, lower as u8) && self.write(addr + 1, upper as u8)
     }
 
     fn copy(&mut self, from: u16, to: u16, n: usize) -> bool {
         for i in 0..n {
-            if let Some(x) = self.read(from+(i as u16)) {
-                if !self.write(to+(i as u16), x) {
+            if let Some(x) = self.read(from + (i as u16)) {
+                if !self.write(to + (i as u16), x) {
                     return false;
                 }
             } else {
                 return false;
             }
-        };
+        }
         true
     }
 
     fn load_from_vec(&mut self, from: &[u8], addr: u16) -> bool {
         for (i, b) in from.iter().enumerate() {
-            if !self.write(addr+(i as u16), *b) {
+            if !self.write(addr + (i as u16), *b) {
                 return false;
             }
-        };
+        }
         true
     }
 }
@@ -74,5 +72,3 @@ impl Addressable for LinearMemory {
         }
     }
 }
-
-

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use macros::{VmInstruction};
+use macros::VmInstruction;
 use crate::register::Register;
 
 /**
@@ -23,7 +23,7 @@ pub enum Instruction {
     #[opcode(0x20)]
     AddStack,
     #[opcode(0x21)]
-    AddRegister(Register, Register), 
+    AddRegister(Register, Register),
     #[opcode(0xF0)]
     Signal(u8),
 }
@@ -65,7 +65,7 @@ fn parse_instruction_arg(ins: u16) -> u8 {
 impl TryFrom<u16> for Instruction {
     type Error = String;
     fn try_from(ins: u16) -> Result<Self, Self::Error> {
-        let op = (ins & 0xff) as u8; 
+        let op = (ins & 0xff) as u8;
         match OpCode::try_from(op)? {
             OpCode::Nop => Ok(Instruction::Nop),
             OpCode::Push => {
@@ -76,13 +76,13 @@ impl TryFrom<u16> for Instruction {
                 let reg = (ins&0xf00) >> 8;
                 Register::from_u8(reg as u8)
                     .ok_or(format!("unknown register 0x{:X}", reg))
-                    .map(|r| Instruction::PopRegister(r))
+                    .map(Instruction::PopRegister)
             },
             OpCode::PushRegister => {
                 let reg = (ins&0xf00) >> 8;
                 Register::from_u8(reg as u8)
                     .ok_or(format!("unknown register 0x{:X}", reg))
-                    .map(|r| Instruction::PushRegister(r))
+                    .map(Instruction::PushRegister)
             }
             OpCode::AddStack => {
                 Ok(Instruction::AddStack)

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
-use macros::VmInstruction;
 use crate::register::Register;
+use macros::VmInstruction;
 
 /**
  * instruction = [ 0 0 0 0 0 0 0 0 | 0 0 0 0 0 0 0 0 ]
@@ -30,11 +30,11 @@ pub enum Instruction {
 
 impl Instruction {
     fn encode_r1(r: Register) -> u16 {
-        (r as u16)&0xf << 8
+        (r as u16) & 0xf << 8
     }
 
     fn encode_r2(r: Register) -> u16 {
-        (r as u16)&0xf << 12
+        (r as u16) & 0xf << 12
     }
 
     fn encode_num(u: u8) -> u16 {
@@ -52,7 +52,7 @@ impl Instruction {
             Self::PopRegister(r) => OpCode::PopRegister as u16 | Self::encode_r1(*r),
             Self::PushRegister(r) => OpCode::PushRegister as u16 | Self::encode_r1(*r),
             Self::AddStack => OpCode::AddStack as u16,
-            Self::AddRegister(r1, r2) => OpCode::AddRegister as u16 | Self::encode_rs(*r1,*r2),
+            Self::AddRegister(r1, r2) => OpCode::AddRegister as u16 | Self::encode_rs(*r1, *r2),
             Self::Signal(x) => OpCode::Signal as u16 | Self::encode_num(*x),
         }
     }
@@ -71,25 +71,23 @@ impl TryFrom<u16> for Instruction {
             OpCode::Push => {
                 let arg = parse_instruction_arg(ins);
                 Ok(Instruction::Push(arg))
-            },
+            }
             OpCode::PopRegister => {
-                let reg = (ins&0xf00) >> 8;
+                let reg = (ins & 0xf00) >> 8;
                 Register::from_u8(reg as u8)
                     .ok_or(format!("unknown register 0x{:X}", reg))
                     .map(Instruction::PopRegister)
-            },
+            }
             OpCode::PushRegister => {
-                let reg = (ins&0xf00) >> 8;
+                let reg = (ins & 0xf00) >> 8;
                 Register::from_u8(reg as u8)
                     .ok_or(format!("unknown register 0x{:X}", reg))
                     .map(Instruction::PushRegister)
             }
-            OpCode::AddStack => {
-                Ok(Instruction::AddStack)
-            },
+            OpCode::AddStack => Ok(Instruction::AddStack),
             OpCode::AddRegister => {
-                let reg1_raw = (ins&0xf00)>>8;
-                let reg2_raw = (ins&0xf000)>>12;
+                let reg1_raw = (ins & 0xf00) >> 8;
+                let reg2_raw = (ins & 0xf000) >> 12;
                 let reg1 = Register::from_u8(reg1_raw as u8)
                     .ok_or(format!("unknown register 0x{:X}", reg1_raw))?;
                 let reg2 = Register::from_u8(reg2_raw as u8)
@@ -99,9 +97,7 @@ impl TryFrom<u16> for Instruction {
             OpCode::Signal => {
                 let arg = parse_instruction_arg(ins);
                 Ok(Instruction::Signal(arg))
-            },
+            }
         }
     }
 }
-
-

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,5 +1,5 @@
-
 #[derive(Debug, Clone, Copy)]
+#[rustfmt::skip]
 #[repr(u8)]
 pub enum Register {
     A, B, C, M, SP, PC, BP, FLAGS,
@@ -20,4 +20,3 @@ impl Register {
         }
     }
 }
-

--- a/src/register.rs
+++ b/src/register.rs
@@ -2,7 +2,7 @@
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum Register {
-    A, B, C, M, SP, PC, BP, FLAGS, 
+    A, B, C, M, SP, PC, BP, FLAGS,
 }
 
 impl Register {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::memory::{LinearMemory, Addressable};
+use crate::memory::{Addressable, LinearMemory};
 use crate::op::Instruction;
 use crate::register::Register;
 
@@ -25,12 +25,13 @@ impl Machine {
             registers: [0; 8],
             signal_handlers: HashMap::new(),
             halt: false,
-            memory: Box::new(LinearMemory::new(8*1024)),
+            memory: Box::new(LinearMemory::new(8 * 1024)),
         }
     }
 
     pub fn state(&self) -> String {
-        format!("A: {} | B: {} | C: {} | M: {}
+        format!(
+            "A: {} | B: {} | C: {} | M: {}
 SP: {} | PC: {} | BP: {}
 FLAGS: {:X}",
             self.get_register(Register::A),
@@ -40,7 +41,8 @@ FLAGS: {:X}",
             self.get_register(Register::SP),
             self.get_register(Register::PC),
             self.get_register(Register::BP),
-            self.get_register(Register::FLAGS))
+            self.get_register(Register::FLAGS)
+        )
     }
 
     pub fn get_register(&self, r: Register) -> u16 {
@@ -76,19 +78,20 @@ FLAGS: {:X}",
 
     pub fn step(&mut self) -> Result<(), String> {
         let pc = self.registers[Register::PC as usize];
-        let instruction = self.memory.read2(pc).ok_or(format!("pc read fail @ 0x{:X}", pc))?;
+        let instruction = self
+            .memory
+            .read2(pc)
+            .ok_or(format!("pc read fail @ 0x{:X}", pc))?;
         self.registers[Register::PC as usize] = pc + 2;
         let op = Instruction::try_from(instruction)?;
         match op {
             Instruction::Nop => Ok(()),
-            Instruction::Push(v) => {
-                self.push(v.into())
-            },
+            Instruction::Push(v) => self.push(v.into()),
             Instruction::PopRegister(r) => {
                 let value = self.pop()?;
                 self.registers[r as usize] = value;
                 Ok(())
-            },
+            }
             Instruction::PushRegister(r) => {
                 self.push(self.registers[r as usize])?;
                 Ok(())
@@ -97,17 +100,18 @@ FLAGS: {:X}",
                 let a = self.pop()?;
                 let b = self.pop()?;
                 self.push(a + b)
-            },
+            }
             Instruction::AddRegister(r1, r2) => {
                 self.registers[r1 as usize] += self.registers[r2 as usize];
                 Ok(())
-            },
+            }
             Instruction::Signal(signal) => {
-                let sig_fn = self.signal_handlers.get(&signal)
+                let sig_fn = self
+                    .signal_handlers
+                    .get(&signal)
                     .ok_or(format!("unknown signal: 0x{:X}", signal))?;
                 sig_fn(self)
-            },
+            }
         }
     }
 }
-

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -13,6 +13,12 @@ pub struct Machine {
     pub memory: Box<dyn Addressable>,
 }
 
+impl Default for Machine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Machine {
     pub fn new() -> Self {
         Self {
@@ -26,7 +32,7 @@ impl Machine {
     pub fn state(&self) -> String {
         format!("A: {} | B: {} | C: {} | M: {}
 SP: {} | PC: {} | BP: {}
-FLAGS: {:X}", 
+FLAGS: {:X}",
             self.get_register(Register::A),
             self.get_register(Register::B),
             self.get_register(Register::C),
@@ -40,7 +46,7 @@ FLAGS: {:X}",
     pub fn get_register(&self, r: Register) -> u16 {
         self.registers[r as usize]
     }
-    
+
     pub fn set_register(&mut self, r: Register, v: u16) {
         self.registers[r as usize] = v;
     }


### PR DESCRIPTION
Not sure if you actually want pull requests. Tell me to go away if not :sweat_smile: 

This pull request simply does some re-formatting/factoring of the code.

Changes:
- Lint code and follow basic rust idioms with `cargo clippy`
- Reformat code with `cargo fmt`
- Remove leading whitespace