### PR TITLE
From<String> implemenation for InstructionParseError

### DIFF
--- a/lib/macros/src/lib.rs
+++ b/lib/macros/src/lib.rs
@@ -50,7 +50,7 @@ fn impl_opcode_struct(ast: &syn::ItemEnum) -> TokenStream {
             });
             field_from_str.push(quote! {
                 stringify!(#name) => {
-                    assert_length(&parts, 1).map_err(|x| Self::Err::Fail(x))?;
+                    assert_length(&parts, 1)?;
                     Ok(Self::#name)
                 }
             });
@@ -76,9 +76,8 @@ fn impl_opcode_struct(ast: &syn::ItemEnum) -> TokenStream {
                     });
                     field_from_str.push(quote! {
                         stringify!(#name) => {
-                            assert_length(&parts, 2).map_err(|x| Self::Err::Fail(x))?;
-                            Ok(Self::#name(Self::parse_numeric(parts[1])
-                                            .map_err(|x| Self::Err::Fail(x))?))
+                            assert_length(&parts, 2)?;
+                            Ok(Self::#name(Self::parse_numeric(parts[1])?))
                         }
                     });
                 }
@@ -100,9 +99,8 @@ fn impl_opcode_struct(ast: &syn::ItemEnum) -> TokenStream {
                     });
                     field_from_str.push(quote! {
                         stringify!(#name) => {
-                            assert_length(&parts, 2).map_err(|x| Self::Err::Fail(x))?;
-                            Ok(Self::#name(Self::parse_numeric_signed(parts[1])
-                                            .map_err(|x| Self::Err::Fail(x))?))
+                            assert_length(&parts, 2)?;
+                            Ok(Self::#name(Self::parse_numeric_signed(parts[1])?))
                         }
                     });
                 }
@@ -123,9 +121,8 @@ fn impl_opcode_struct(ast: &syn::ItemEnum) -> TokenStream {
                     });
                     field_from_str.push(quote! {
                         stringify!(#name) => {
-                            assert_length(&parts, 2).map_err(|x| Self::Err::Fail(x))?;
-                            Ok(Self::#name(Register::from_str(parts[1])
-                                           .map_err(|x| Self::Err::Fail(x))?))
+                            assert_length(&parts, 2)?;
+                            Ok(Self::#name(Register::from_str(parts[1])?))
                         }
                     });
                 }
@@ -152,10 +149,10 @@ fn impl_opcode_struct(ast: &syn::ItemEnum) -> TokenStream {
                     });
                     field_from_str.push(quote! {
                         stringify!(#name) => {
-                            assert_length(&parts, 3).map_err(|x| Self::Err::Fail(x))?;
+                            assert_length(&parts, 3)?;
                             Ok(Self::#name(
-                                    Register::from_str(parts[1]).map_err(|x| Self::Err::Fail(x))?,
-                                    Register::from_str(parts[2]).map_err(|x| Self::Err::Fail(x))?))
+                                    Register::from_str(parts[1])?,
+                                    Register::from_str(parts[2])?))
                         }
                     });
                 }

--- a/src/op.rs
+++ b/src/op.rs
@@ -16,6 +16,12 @@ pub enum InstructionParseError {
     Fail(String),
 }
 
+impl From<String> for InstructionParseError {
+    fn from(value: String) -> Self {
+        Self::Fail(value)
+    }
+}
+
 #[derive(Debug, VmInstruction)]
 pub enum Instruction {
     #[opcode(0x0)]


### PR DESCRIPTION
Currently you are doing manual type coercion to make your errors compatible. My pull request implements From<String> for InstructionParseError so that the Rust compiler can coerce the errors automatically.