### PR TITLE
Reworked ISA

### DIFF
--- a/lib/macros/Cargo.toml
+++ b/lib/macros/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
+proc-macro2 = "1.0.79"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
 

--- a/lib/macros/Cargo.toml
+++ b/lib/macros/Cargo.toml
@@ -11,3 +11,4 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
+

--- a/lib/macros/src/lib.rs
+++ b/lib/macros/src/lib.rs
@@ -110,7 +110,7 @@ fn impl_opcode_struct(ast: &syn::ItemEnum) -> Result<proc_macro2::TokenStream, S
                         let argname = get_arg_name(i)?;
                         let part_index = i+1;
                         part_encoders.extend(quote!{
-                            op_parts[#i] = ((#argname.value&0xf)as u16) | ((#argname.value as u16)&0xe00);
+                            op_parts[#i] = ((#argname.value&0xf)as u16) | (((#argname.value as u16)&0x70) << 5);
                         });
                         part_decoders.extend(quote!{
                             let #argname = Literal7Bit::new(((ins&0xf) as u8) | (((ins&0xe00)>>5) as u8));
@@ -128,8 +128,8 @@ fn impl_opcode_struct(ast: &syn::ItemEnum) -> Result<proc_macro2::TokenStream, S
                         let argname = get_arg_name(i)?;
                         let part_index = i+1;
                         part_encoders.extend(quote!{
-                            op_parts[#i] = ((#argname.value&0xf) as u16) | ((#argname.value&0xe00) as u16) 
-                                | ((#argname.value&0x7000) as u16);
+                            op_parts[#i] = ((#argname.value&0xf) as u16) | (((#argname.value&0x70) as u16) << 5)
+                                | ((#argname.value&0x0380 as u16) << 5);
                         });
                         part_decoders.extend(quote!{
                             let #argname = Literal10Bit::new(((ins&0xf) as u16) | (((ins&0xe00)>>5) as u16) | (((ins&0x7000)>>5) as u16));

--- a/lib/macros/src/lib.rs
+++ b/lib/macros/src/lib.rs
@@ -51,7 +51,7 @@ fn impl_opcode_struct(ast: &syn::ItemEnum) -> Result<proc_macro2::TokenStream, S
     let mut field_from_str: proc_macro2::TokenStream = quote!();
     for x in ast.variants.iter() {
         let name = &x.ident;
-        let opcode_value = variant_opcode_value(&x);
+        let opcode_value = variant_opcode_value(x);
         if let syn::Fields::Unit = &x.fields {
             field_u16_encodings.extend(quote! {
                 Self::#name => #opcode_value as u16
@@ -79,7 +79,7 @@ fn impl_opcode_struct(ast: &syn::ItemEnum) -> Result<proc_macro2::TokenStream, S
             let mut part_encoders: proc_macro2::TokenStream = quote!();
             let mut part_decoders: proc_macro2::TokenStream = quote!();
             let mut part_stringers: proc_macro2::TokenStream = quote!();
-            for (i, &ref type_name) in types.iter().enumerate() {
+            for (i, type_name) in types.iter().enumerate() {
                 match (type_name.as_str(), i) {
                     ("Register", 0) => {
                         part_encoders.extend(quote!(op_parts[0] = a0.as_mask_first();));
@@ -319,7 +319,7 @@ fn impl_opcode_struct(ast: &syn::ItemEnum) -> Result<proc_macro2::TokenStream, S
             }
         }
 
-        fn assert_length(parts: &Vec<&str>, n: usize) -> Result<(), String> {
+        fn assert_length(parts: &[&str], n: usize) -> Result<(), String> {
             if parts.len() == n {
                 Ok(())
             } else {

--- a/lib/macros/src/lib.rs
+++ b/lib/macros/src/lib.rs
@@ -222,7 +222,21 @@ fn impl_opcode_struct(ast: &syn::ItemEnum) -> Result<proc_macro2::TokenStream, S
                             })?;
                         });
                     }
-
+                    ("StackOp", i) => {
+                        let argname = get_arg_name(i)?;
+                        let part_index = i + 1;
+                        part_encoders.extend(quote! {
+                            op_parts[#i] = (*#argname as u16)&0xf;
+                        });
+                        part_decoders.extend(quote! {
+                            let #argname = StackOp::try_from(ins&0xf)?;
+                        });
+                        part_stringers.extend(quote!{
+                            let #argname = StackOp::from_str(&parts[#part_index]).map_err(|x| {
+                                Self::Err::Fail(x)
+                            })?;
+                        });
+                    }
                     ("u16", i) => {
                         let argname = get_arg_name(i)?;
                         let part_index = i + 1;

--- a/src/bin/asm.rs
+++ b/src/bin/asm.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), String> {
         if line_inner.is_empty() {
             continue;
         }
-        if line_inner.chars().next().unwrap() == ';' {
+        if line_inner.starts_with(';') {
             continue;
         }
         match Instruction::from_str(&line_inner) {

--- a/src/bin/asm.rs
+++ b/src/bin/asm.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs::File;
 use std::io;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Write, stdin, Read};
 use std::path::Path;
 use std::str::FromStr;
 
@@ -15,17 +15,13 @@ fn main() -> Result<(), String> {
         panic!("usage: {} <input>", args[0]);
     }
 
-    let file = File::open(Path::new(&args[1])).map_err(|x| format!("failed to open: {}", x))?;
+    let reader: Box<dyn Read> = match args[1].as_ref() {
+        "-" => Box::new(stdin()),
+        _ => Box::new(File::open(Path::new(&args[1])).map_err(|x| format!("failed to open: {}", x))?),
+    };
+
     let mut output: Vec<u8> = Vec::new();
-    /*
-     * Push 10
-     * Push 240
-     * AddStack
-     * PopRegister A
-     * Signal $f0
-     *
-     */
-    for (i, line) in BufReader::new(file).lines().enumerate() {
+    for (i, line) in BufReader::new(reader).lines().enumerate() {
         let line_inner = line.map_err(|_x| "foo")?;
         if line_inner.is_empty() {
             continue;

--- a/src/bin/asm.rs
+++ b/src/bin/asm.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), String> {
      * Signal $f0
      *
      */
-    for line in BufReader::new(file).lines() {
+    for (i, line) in BufReader::new(file).lines().enumerate() {
         let line_inner = line.map_err(|_x| "foo")?;
         if line_inner.is_empty() {
             continue;
@@ -41,7 +41,7 @@ fn main() -> Result<(), String> {
                 output.push((raw_instruction >> 8) as u8);
             }
             Err(InstructionParseError::Fail(s)) => {
-                panic!("{}", s);
+                panic!("{} @ {}: {}", s, i, line_inner);
             }
             _ => continue,
         }

--- a/src/bin/dis.rs
+++ b/src/bin/dis.rs
@@ -21,8 +21,10 @@ fn main() -> Result<(), String> {
         .map_err(|x| format!("read: {}", x))?;
     unsafe {
         let (_, instructions, _) = program.align_to::<u16>();
-        for ins in instructions.iter() {
-            let value = Instruction::try_from(*ins)?;
+        for (i, ins) in instructions.iter().enumerate() {
+            let value = Instruction::try_from(*ins).map_err(|x| {
+                format!("@ {}({:04X}): {}", i, ins, x)
+            })?;
             println!("{value}")
         }
     }

--- a/src/bin/dis.rs
+++ b/src/bin/dis.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufReader, Read, stdin};
 use std::path::Path;
 
 use simplevm::Instruction;
@@ -13,8 +13,12 @@ fn main() -> Result<(), String> {
         panic!("usage: {} <input>", args[0]);
     }
 
-    let file = File::open(Path::new(&args[1])).map_err(|x| format!("failed to open: {}", x))?;
-    let mut reader = BufReader::new(file);
+    let tgt: Box<dyn Read> = match args[1].as_ref() {
+        "-" => Box::new(stdin()),
+        _ => Box::new(File::open(Path::new(&args[1])).map_err(|x| format!("failed to open: {}", x))?),
+    };
+
+    let mut reader = BufReader::new(tgt);
     let mut program: Vec<u8> = Vec::new();
     reader
         .read_to_end(&mut program)

--- a/src/bin/dis.rs
+++ b/src/bin/dis.rs
@@ -22,9 +22,8 @@ fn main() -> Result<(), String> {
     unsafe {
         let (_, instructions, _) = program.align_to::<u16>();
         for (i, ins) in instructions.iter().enumerate() {
-            let value = Instruction::try_from(*ins).map_err(|x| {
-                format!("@ {}({:04X}): {}", i, ins, x)
-            })?;
+            let value =
+                Instruction::try_from(*ins).map_err(|x| format!("@ {}({:04X}): {}", i, ins, x))?;
             println!("{value}")
         }
     }

--- a/src/bin/vm.rs
+++ b/src/bin/vm.rs
@@ -24,7 +24,7 @@ pub fn main() -> Result<(), String> {
         .read_to_end(&mut program)
         .map_err(|x| format!("read: {}", x))?;
 
-    let mut vm = Machine::new();
+    let mut vm = Machine::new(1024*4);
     vm.set_register(Register::SP, 0x1000);
     vm.define_handler(0xf0, signal_halt);
     vm.memory.load_from_vec(&program, 0);

--- a/src/bin/vm.rs
+++ b/src/bin/vm.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufReader, Read, stdin};
 use std::path::Path;
 
 use simplevm::{Machine, Register};
@@ -16,9 +16,12 @@ pub fn main() -> Result<(), String> {
         panic!("usage: {} <input>", args[0]);
     }
 
-    let file = File::open(Path::new(&args[1])).map_err(|x| format!("failed to open: {}", x))?;
+    let reader: Box<dyn Read> = match args[1].as_ref() {
+        "-" => Box::new(stdin()),
+        _ => Box::new(File::open(Path::new(&args[1])).map_err(|x| format!("failed to open: {}", x))?),
+    };
 
-    let mut reader = BufReader::new(file);
+    let mut reader = BufReader::new(reader);
     let mut program: Vec<u8> = Vec::new();
     reader
         .read_to_end(&mut program)

--- a/src/bin/vm.rs
+++ b/src/bin/vm.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use simplevm::{Machine, Register};
 
-fn signal_halt(vm: &mut Machine) -> Result<(), String> {
+fn signal_halt(vm: &mut Machine, _: u16) -> Result<(), String> {
     vm.halt = true;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ pub mod vm;
 pub use crate::op::*;
 pub use crate::register::*;
 pub use crate::vm::*;
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,3 @@ pub mod vm;
 pub use crate::op::*;
 pub use crate::register::*;
 pub use crate::vm::*;
-

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -38,6 +38,17 @@ pub trait Addressable {
         }
         true
     }
+
+    fn zero(&mut self, from: u32, to: u32) -> bool {
+        for i in from..to {
+            if !self.write(i, 0) {
+                return false;
+            }
+        };
+        true
+    }
+
+    fn zero_all(&mut self) -> bool;
 }
 
 pub struct LinearMemory {
@@ -70,5 +81,9 @@ impl Addressable for LinearMemory {
         } else {
             false
         }
+    }
+
+    fn zero_all(&mut self) -> bool {
+        self.zero(0, self.size as u32)
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,8 +1,8 @@
 pub trait Addressable {
-    fn read(&self, addr: u16) -> Option<u8>;
-    fn write(&mut self, addr: u16, value: u8) -> bool;
+    fn read(&self, addr: u32) -> Option<u8>;
+    fn write(&mut self, addr: u32, value: u8) -> bool;
 
-    fn read2(&self, addr: u16) -> Option<u16> {
+    fn read2(&self, addr: u32) -> Option<u16> {
         if let Some(x0) = self.read(addr) {
             if let Some(x1) = self.read(addr + 1) {
                 return Some((x0 as u16) | ((x1 as u16) << 8));
@@ -11,16 +11,16 @@ pub trait Addressable {
         None
     }
 
-    fn write2(&mut self, addr: u16, value: u16) -> bool {
+    fn write2(&mut self, addr: u32, value: u16) -> bool {
         let lower = value & 0xff;
         let upper = (value & 0xff00) >> 8;
         self.write(addr, lower as u8) && self.write(addr + 1, upper as u8)
     }
 
-    fn copy(&mut self, from: u16, to: u16, n: usize) -> bool {
+    fn copy(&mut self, from: u32, to: u32, n: usize) -> bool {
         for i in 0..n {
-            if let Some(x) = self.read(from + (i as u16)) {
-                if !self.write(to + (i as u16), x) {
+            if let Some(x) = self.read(from + (i as u32)) {
+                if !self.write(to + (i as u32), x) {
                     return false;
                 }
             } else {
@@ -30,9 +30,9 @@ pub trait Addressable {
         true
     }
 
-    fn load_from_vec(&mut self, from: &[u8], addr: u16) -> bool {
+    fn load_from_vec(&mut self, from: &[u8], addr: u32) -> bool {
         for (i, b) in from.iter().enumerate() {
-            if !self.write(addr + (i as u16), *b) {
+            if !self.write(addr + (i as u32), *b) {
                 return false;
             }
         }
@@ -55,7 +55,7 @@ impl LinearMemory {
 }
 
 impl Addressable for LinearMemory {
-    fn read(&self, addr: u16) -> Option<u8> {
+    fn read(&self, addr: u32) -> Option<u8> {
         if (addr as usize) < self.size {
             Some(self.bytes[addr as usize])
         } else {
@@ -63,7 +63,7 @@ impl Addressable for LinearMemory {
         }
     }
 
-    fn write(&mut self, addr: u16, value: u8) -> bool {
+    fn write(&mut self, addr: u32, value: u8) -> bool {
         if (addr as usize) < self.size {
             self.bytes[addr as usize] = value;
             true

--- a/src/op.rs
+++ b/src/op.rs
@@ -49,7 +49,7 @@ impl Literal7Bit {
         if sgn == 0 {
             (self.value & 0x3f) as i8
         } else {
-            -1 * ((self.value & 0x3f) as i8)
+            -((self.value & 0x3f) as i8)
         }
     }
 }

--- a/src/op.rs
+++ b/src/op.rs
@@ -185,17 +185,17 @@ pub enum Instruction {
     ShiftRightLogical(Register, Register, Nibble),
     #[opcode(0x7)]
     ShiftRightArithmetic(Register, Register, Nibble),
-    #[opcode(0x7)]
-    Load(Register, Register, Register), // R0 = RAM[R1 | (R2<<16)]
     #[opcode(0x8)]
+    Load(Register, Register, Register), // R0 = RAM[R1 | (R2<<16)]
+    #[opcode(0x9)]
     Store(Register, Register, Register), // RAM[R1 | (R2<<16)] = R0
+    #[opcode(0xb)]
+    Jump(Literal10Bit),
     /*
     #[opcode(0x9)]
     Test(Register, Register, TestOp),
     #[opcode(0xa)]
     AddIf(Register, Nibble),
-    #[opcode(0xb)]
-    Jump(Literal10Bit),
     #[opcode(0xc)]
     Stack(Register, Register, StackOp),
     #[opcode(0xd)]
@@ -222,6 +222,9 @@ mod test {
             ShiftLeft(M, BP, Nibble::new(0xe)),
             ShiftRightLogical(M, BP, Nibble::new(0xe)),
             ShiftRightArithmetic(M, BP, Nibble::new(0xe)),
+            Load(A, C, M),
+            Store(C, A, M),
+            Jump(Literal10Bit::new(1000)),
             System(A, B, Nibble::new(0x3)),
         ];
         let encoded: Vec<_> = ops.iter().map(|x| x.encode_u16()).collect();

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,6 +1,6 @@
-use std::fmt;
 use crate::register::Register;
 use macros::VmInstruction;
+use std::fmt;
 
 /**
  * TYPE A
@@ -36,7 +36,7 @@ pub trait InstructionPart {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Literal7Bit {
-    pub value: u8, 
+    pub value: u8,
 }
 
 impl Literal7Bit {
@@ -80,13 +80,13 @@ impl fmt::Display for Literal10Bit {
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TestOp {
-    Eq, 
-    Neq, 
-    Lt, 
-    Lte, 
-    BothZero, 
-    EitherNonZero, 
-    BothNonZero, 
+    Eq,
+    Neq,
+    Lt,
+    Lte,
+    BothZero,
+    EitherNonZero,
+    BothNonZero,
 }
 
 impl TryFrom<u16> for TestOp {
@@ -107,7 +107,7 @@ impl TryFrom<u16> for TestOp {
 
 impl InstructionPart for TestOp {
     fn as_mask(&self) -> u16 {
-        (*self as u16)&0xf
+        (*self as u16) & 0xf
     }
     fn from_instruction(ins: u16) -> Self {
         TestOp::try_from(ins).unwrap()
@@ -127,7 +127,7 @@ pub enum StackOp {
 
 impl InstructionPart for StackOp {
     fn as_mask(&self) -> u16 {
-        (*self as u16)&0xf
+        (*self as u16) & 0xf
     }
 
     fn from_instruction(ins: u16) -> Self {
@@ -157,7 +157,7 @@ pub struct Nibble {
 
 impl Nibble {
     pub fn new(value: u8) -> Self {
-        Self{ value } 
+        Self { value }
     }
 }
 
@@ -209,15 +209,15 @@ pub enum Instruction {
 #[cfg(test)]
 mod test {
     use super::Instruction::*;
-    use crate::register::Register::*;
     use super::*;
+    use crate::register::Register::*;
 
     #[test]
     fn test_encodings() -> Result<(), String> {
         let ops = vec![
-            Imm(M, 0x30), 
+            Imm(M, 0x30),
             AddImm(C, Literal7Bit::new(0x20)),
-            Add(C, B, A), 
+            Add(C, B, A),
             Sub(PC, BP, SP),
             AddImmSigned(A, Literal7Bit::new(0x7)),
             System(A, B, Nibble::new(0x3)),

--- a/src/op.rs
+++ b/src/op.rs
@@ -185,11 +185,11 @@ pub enum Instruction {
     ShiftRightLogical(Register, Register, Nibble),
     #[opcode(0x7)]
     ShiftRightArithmetic(Register, Register, Nibble),
-    /*
     #[opcode(0x7)]
     Load(Register, Register, Register), // R0 = RAM[R1 | (R2<<16)]
     #[opcode(0x8)]
     Store(Register, Register, Register), // RAM[R1 | (R2<<16)] = R0
+    /*
     #[opcode(0x9)]
     Test(Register, Register, TestOp),
     #[opcode(0xa)]

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,14 +1,14 @@
 use std::fmt;
-use std::str::FromStr;
+// use std::str::FromStr;
 
 use crate::register::Register;
 use macros::VmInstruction;
 
 /**
  * TYPE A
- * 0RRR LLLL LLLL LLLL
+ * 1RRR LLLL LLLL LLLL
  * TYPE B
- * 1RRR SSSA AAAA DDDD
+ * 0RRR SSSA AAAA DDDD
  * Add (A = 0)
  * [ assume register A = 1, B = 2 ]
  * Reg[D] = Reg[R] + Reg[S]
@@ -42,6 +42,10 @@ pub struct Literal7Bit {
 }
 
 impl Literal7Bit {
+    pub fn new(value: u8) -> Self {
+        Self { value }
+    }
+
     pub fn as_signed(&self) -> i8 {
         let sgn = (self.value & 0x40) >> 7;
         if sgn == 0 {
@@ -72,6 +76,12 @@ impl fmt::Display for Literal7Bit {
 #[derive(Debug)]
 pub struct Literal10Bit {
     pub value: u16,
+}
+
+impl Literal10Bit {
+    pub fn new(value: u16) -> Self {
+        Self { value }
+    }
 }
 
 impl fmt::Display for Literal10Bit {
@@ -221,9 +231,9 @@ pub enum Instruction {
     Stack(Register, Register, StackOp),
     #[opcode(0xd)]
     LoadStackOffset(Register, Register, Nibble),
-    */
     #[opcode(0xe)]
     System(Register, Register, Nibble),
+    */
 }
 
 #[cfg(test)]

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,5 +1,6 @@
 use crate::register::Register;
-use macros::VmInstruction;
+use macros::{VmInstruction, StringyEnum};
+use std::str::FromStr;
 use std::fmt;
 
 /**
@@ -78,12 +79,14 @@ impl fmt::Display for Literal10Bit {
 }
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, StringyEnum)]
 pub enum TestOp {
     Eq,
     Neq,
     Lt,
     Lte,
+    Gt,
+    Gte,
     BothZero,
     EitherNonZero,
     BothNonZero,
@@ -97,6 +100,8 @@ impl TryFrom<u16> for TestOp {
             x if x == TestOp::Neq as u16 => Ok(TestOp::Neq),
             x if x == TestOp::Lt as u16 => Ok(TestOp::Lt),
             x if x == TestOp::Lte as u16 => Ok(TestOp::Lte),
+            x if x == TestOp::Gt as u16 => Ok(TestOp::Gt),
+            x if x == TestOp::Gte as u16 => Ok(TestOp::Gte),
             x if x == TestOp::BothZero as u16 => Ok(TestOp::BothZero),
             x if x == TestOp::BothNonZero as u16 => Ok(TestOp::BothNonZero),
             x if x == TestOp::EitherNonZero as u16 => Ok(TestOp::EitherNonZero),
@@ -189,13 +194,13 @@ pub enum Instruction {
     Load(Register, Register, Register), // R0 = RAM[R1 | (R2<<16)]
     #[opcode(0x9)]
     Store(Register, Register, Register), // RAM[R1 | (R2<<16)] = R0
-    #[opcode(0xb)]
-    Jump(Literal10Bit),
-    /*
-    #[opcode(0x9)]
-    Test(Register, Register, TestOp),
     #[opcode(0xa)]
+    Jump(Literal10Bit),
+    #[opcode(0xb)]
+    Test(Register, Register, TestOp),
+    #[opcode(0xc)]
     AddIf(Register, Nibble),
+    /*
     #[opcode(0xc)]
     Stack(Register, Register, StackOp),
     #[opcode(0xd)]
@@ -225,6 +230,8 @@ mod test {
             Load(A, C, M),
             Store(C, A, M),
             Jump(Literal10Bit::new(1000)),
+            Test(BP, A, TestOp::Gte),
+            AddIf(PC, Nibble::new(0x0)),
             System(A, B, Nibble::new(0x3)),
         ];
         let encoded: Vec<_> = ops.iter().map(|x| x.encode_u16()).collect();

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,6 +1,4 @@
 use std::fmt;
-// use std::str::FromStr;
-
 use crate::register::Register;
 use macros::VmInstruction;
 
@@ -56,17 +54,6 @@ impl Literal7Bit {
     }
 }
 
-impl InstructionPart for Literal7Bit {
-    fn as_mask(&self) -> u16 {
-        ((self.value&0xf) as u16) | ((self.value as u16)&0xe00)
-    }
-    fn from_instruction(ins: u16) -> Self {
-        Self {
-            value: ((ins&0xf) as u8) | (((ins&0xe00)>>5) as u8),
-        }
-    }
-}
-
 impl fmt::Display for Literal7Bit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.value)
@@ -88,18 +75,6 @@ impl fmt::Display for Literal10Bit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.value)
     }
-}
-
-impl InstructionPart for Literal10Bit {
-    fn as_mask(&self) -> u16 {
-        ((self.value&0xf) as u16) | ((self.value&0xe00) as u16) | ((self.value&0x7000) as u16)
-    }
-    fn from_instruction(ins: u16) -> Self {
-        Self {
-            value: ((ins&0xf) as u16) | (((ins&0xe00)>>5) as u16) | (((ins&0x7000)>>5) as u16),
-        }
-    }
-
 }
 
 #[repr(u8)]
@@ -175,25 +150,20 @@ impl TryFrom<u16> for StackOp {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Nibble {
     pub value: u8,
+}
+
+impl Nibble {
+    pub fn new(value: u8) -> Self {
+        Self{ value } 
+    }
 }
 
 impl fmt::Display for Nibble {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.value)
-    }
-}
-
-impl InstructionPart for Nibble {
-    fn as_mask(&self) -> u16 {
-        (self.value as u16)&0xf
-    }
-    fn from_instruction(ins: u16) -> Self {
-        Self {
-            value: (ins&0xf) as u8, 
-        }
     }
 }
 
@@ -231,9 +201,9 @@ pub enum Instruction {
     Stack(Register, Register, StackOp),
     #[opcode(0xd)]
     LoadStackOffset(Register, Register, Nibble),
+    */
     #[opcode(0xe)]
     System(Register, Register, Nibble),
-    */
 }
 
 #[cfg(test)]

--- a/src/op.rs
+++ b/src/op.rs
@@ -38,12 +38,23 @@ pub trait InstructionPart {
 
 #[derive(Debug)]
 pub struct Literal7Bit {
-    value: u8, 
+    pub value: u8, 
+}
+
+impl Literal7Bit {
+    pub fn as_signed(&self) -> i8 {
+        let sgn = (self.value & 0x40) >> 7;
+        if sgn == 0 {
+            (self.value & 0x3f) as i8
+        } else {
+            -1 * ((self.value & 0x3f) as i8)
+        }
+    }
 }
 
 impl InstructionPart for Literal7Bit {
     fn as_mask(&self) -> u16 {
-        ((self.value&0xf) as u16) | ((self.value&0xe00) as u16)
+        ((self.value&0xf) as u16) | ((self.value as u16)&0xe00)
     }
     fn from_instruction(ins: u16) -> Self {
         Self {
@@ -60,7 +71,7 @@ impl fmt::Display for Literal7Bit {
 
 #[derive(Debug)]
 pub struct Literal10Bit {
-    value: u16,
+    pub value: u16,
 }
 
 impl fmt::Display for Literal10Bit {
@@ -156,7 +167,7 @@ impl TryFrom<u16> for StackOp {
 
 #[derive(Debug)]
 pub struct Nibble {
-    value: u8,
+    pub value: u8,
 }
 
 impl fmt::Display for Nibble {
@@ -186,9 +197,9 @@ pub enum Instruction {
     Sub(Register, Register, Register),
     #[opcode(0x2)]
     AddImm(Register, Literal7Bit),
-    /*
     #[opcode(0x3)]
     AddImmSigned(Register, Literal7Bit),
+    /*
     #[opcode(0x4)]
     ShiftLeft(Register, Register, Nibble),
     #[opcode(0x5)]
@@ -210,9 +221,9 @@ pub enum Instruction {
     Stack(Register, Register, StackOp),
     #[opcode(0xd)]
     LoadStackOffset(Register, Register, Nibble),
+    */
     #[opcode(0xe)]
     System(Register, Register, Nibble),
-    */
 }
 
 #[cfg(test)]

--- a/src/op.rs
+++ b/src/op.rs
@@ -5,11 +5,24 @@ use crate::register::Register;
 use macros::VmInstruction;
 
 /**
- * instruction = [ 0 0 0 0 0 0 0 0 | 0 0 0 0 0 0 0 0 ]
- *                 OPERATOR        | ARG(s)
- *                                 | 8 bit literal
- *                                 | REG1  | REG2
-*/
+ * TYPE A
+ * 0RRR LLLL LLLL LLLL
+ * TYPE B
+ * 1RRR SSSA AAAA DDDD
+ * Add (A = 0)
+ * [ assume register A = 1, B = 2 ]
+ * Reg[D] = Reg[R] + Reg[S]
+ * 1001 0100 0000 0001
+ * Reg[0] is always = 0
+ * Reg[A] = Reg[B] + Reg[Zero]
+ * 1000 0100 0000 0001
+ *
+ * Stack (A = 0xf)
+ * Push (D = 0)
+ * 1001 1010 1111 0000
+ * Pop (D = 1)
+ * 1010 1010 1111 0001
+ */
 
 pub enum InstructionParseError {
     NoContent,

--- a/src/op.rs
+++ b/src/op.rs
@@ -220,6 +220,7 @@ mod test {
             Add(C, B, A), 
             Sub(PC, BP, SP),
             AddImmSigned(A, Literal7Bit::new(0x7)),
+            System(A, B, Nibble::new(0x3)),
         ];
         let encoded: Vec<_> = ops.iter().map(|x| x.encode_u16()).collect();
         for (l, r) in ops.iter().zip(encoded.iter()) {

--- a/src/op.rs
+++ b/src/op.rs
@@ -22,6 +22,8 @@ use macros::VmInstruction;
  * 1001 1010 1111 0000
  * Pop (D = 1)
  * 1010 1010 1111 0001
+ *
+ * 1000 0000 0000 0000
  */
 
 pub enum InstructionParseError {
@@ -29,49 +31,143 @@ pub enum InstructionParseError {
     Fail(String),
 }
 
+pub trait InstructionPart {
+    fn as_mask(&self) -> u16;
+    fn from_instruction(ins: u16) -> Self;
+}
+
+pub struct Literal7Bit {
+    value: u8, 
+}
+
+impl InstructionPart for Literal7Bit {
+    fn as_mask(&self) -> u16 {
+        ((self.value&0xf) as u16) | ((self.value&0xe00) as u16)
+    }
+    fn from_instruction(ins: u16) -> Self {
+        Self {
+            value: ((ins&0xf) as u8) | (((ins&0xe00)>>5) as u8),
+        }
+    }
+}
+
+pub struct Literal10Bit {
+    value: u16,
+}
+
+impl InstructionPart for Literal10Bit {
+    fn as_mask(&self) -> u16 {
+        ((self.value&0xf) as u16) | ((self.value&0xe00) as u16) | ((self.value&0x7000) as u16)
+    }
+    fn from_instruction(ins: u16) -> Self {
+        Self {
+            value: ((ins&0xf) as u16) | (((ins&0xe00)>>5) as u16) | (((ins&0x7000)>>5) as u16),
+        }
+    }
+
+}
+
+#[repr(u8)]
+#[derive(Debug, PartialEq, Eq)]
+pub enum TestOp {
+    Eq, 
+    Neq, 
+    Lt, 
+    Lte, 
+    BothZero, 
+    EitherNonZero, 
+    BothNonZero, 
+}
+
+impl TryFrom<u16> for TestOp {
+    type Error = String;
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            x if x == TestOp::Eq as u16 => Ok(TestOp::Eq),
+            x if x == TestOp::Neq as u16 => Ok(TestOp::Neq),
+            x if x == TestOp::Lt as u16 => Ok(TestOp::Lt),
+            x if x == TestOp::Lte as u16 => Ok(TestOp::Lte),
+            x if x == TestOp::BothZero as u16 => Ok(TestOp::BothZero),
+            x if x == TestOp::BothNonZero as u16 => Ok(TestOp::BothNonZero),
+            x if x == TestOp::EitherNonZero as u16 => Ok(TestOp::EitherNonZero),
+            _ => Err(format!("unknown test op value {}", value)),
+        }
+    }
+}
+
+impl InstructionPart for TestOp {
+    fn as_mask(&self) -> u16 {
+        (self as u16)&0xf
+    }
+    fn from_instruction(ins: u16) -> Self {
+        TestOp::try_from(ins).unwrap()
+    }
+}
+
+#[repr(u8)]
+#[derive(Debug, PartialEq, Eq)]
+pub enum StackOp {
+    Pop,
+    Push,
+    Peek,
+    Swap,
+    Dup,
+    Rotate,
+}
+
+impl InstructionPart for StackOp {
+    fn as_mask(&self) -> u16 {
+        (self as u16)&0xf
+    }
+}
+
+pub struct Nibble {
+    value: u8,
+}
+
+impl InstructionPart for Nibble {
+    fn as_mask(&self) -> u16 {
+        (self.value as u16)&0xf
+    }
+}
+
 #[derive(Debug, VmInstruction)]
 pub enum Instruction {
+    #[opcode(0xff)]
+    Imm(Register, u16),
     #[opcode(0x0)]
-    Nop,
+    Add(Register, Register, Register),
     #[opcode(0x1)]
-    Push(u8),
+    Sub(Register, Register, Register),
     #[opcode(0x2)]
-    PopRegister(Register),
+    AddImm(Register, Literal7Bit),
+    /*
     #[opcode(0x3)]
-    PushRegister(Register),
+    AddImmSigned(Register, Literal7Bit),
     #[opcode(0x4)]
-    SetRegister(Register, Register),
+    ShiftLeft(Register, Register, Nibble),
+    #[opcode(0x5)]
+    ShiftRightLogical(Register, Register, Nibble),
     #[opcode(0x6)]
-    LoadARegister(Register),
+    ShiftRightArithmetic(Register, Register, Nibble),
+
     #[opcode(0x7)]
-    LoadAImm(u8),
+    Load(Register, Register, Register), // R0 = RAM[R1 | (R2<<16)]
     #[opcode(0x8)]
-    LoadBRegister(Register),
+    Store(Register, Register, Register), // RAM[R1 | (R2<<16)] = R0
     #[opcode(0x9)]
-    LoadBImm(u8),
-    #[opcode(0xA)]
-    LoadCRegister(Register),
-    #[opcode(0xB)]
-    LoadCImm(u8),
-    #[opcode(0x20)]
-    AddStack,
-    #[opcode(0x21)]
-    AddRegister(Register, Register),
-    #[opcode(0x22)]
-    SubStack,
-    #[opcode(0x23)]
-    SubRegister(Register, Register),
-
-    #[opcode(0x40)]
-    BranchImm(i8), // branch relative (PC += x if FLAGS[c])
-    #[opcode(0x41)]
-    BranchRegister(Register), // branch absolute (PC = Registers[r] if FLAGS[c])
-
-    #[opcode(0x50)]
-    IfZero(Register),
-
-    #[opcode(0xF0)]
-    Signal(u8),
+    Test(Register, Register, TestOp),
+    #[opcode(0xa)]
+    AddIf(Register, Nibble),
+    #[opcode(0xb)]
+    Jump(Literal10Bit),
+    #[opcode(0xc)]
+    Stack(Register, Register, StackOp),
+    #[opcode(0xd)]
+    LoadStackOffset(Register, Register, Nibble),
+    #[opcode(0xe)]
+    System(Register, Register, Nibble),
+    */
 }
 
 #[cfg(test)]

--- a/src/op.rs
+++ b/src/op.rs
@@ -179,14 +179,13 @@ pub enum Instruction {
     AddImm(Register, Literal7Bit),
     #[opcode(0x4)]
     AddImmSigned(Register, Literal7Bit),
-    /*
-    #[opcode(0x4)]
-    ShiftLeft(Register, Register, Nibble),
     #[opcode(0x5)]
-    ShiftRightLogical(Register, Register, Nibble),
+    ShiftLeft(Register, Register, Nibble),
     #[opcode(0x6)]
+    ShiftRightLogical(Register, Register, Nibble),
+    #[opcode(0x7)]
     ShiftRightArithmetic(Register, Register, Nibble),
-
+    /*
     #[opcode(0x7)]
     Load(Register, Register, Register), // R0 = RAM[R1 | (R2<<16)]
     #[opcode(0x8)]
@@ -220,6 +219,9 @@ mod test {
             Add(C, B, A),
             Sub(PC, BP, SP),
             AddImmSigned(A, Literal7Bit::new(0x7)),
+            ShiftLeft(M, BP, Nibble::new(0xe)),
+            ShiftRightLogical(M, BP, Nibble::new(0xe)),
+            ShiftRightArithmetic(M, BP, Nibble::new(0xe)),
             System(A, B, Nibble::new(0x3)),
         ];
         let encoded: Vec<_> = ops.iter().map(|x| x.encode_u16()).collect();

--- a/src/register.rs
+++ b/src/register.rs
@@ -5,7 +5,7 @@ pub enum RegisterFlag {
     Compare = 0x1,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Register {
     A,

--- a/src/register.rs
+++ b/src/register.rs
@@ -34,27 +34,27 @@ impl Register {
     }
 
     pub fn as_mask_first(&self) -> u16 {
-        ((*self as u16)&0x7) << 12
+        ((*self as u16) & 0x7) << 12
     }
 
     pub fn from_instruction_first(ins: u16) -> Option<Self> {
-        Self::from_u8(((ins&0x7000)>>12) as u8)
+        Self::from_u8(((ins & 0x7000) >> 12) as u8)
     }
 
     pub fn as_mask_second(&self) -> u16 {
-        ((*self as u16)&0x7) << 9
+        ((*self as u16) & 0x7) << 9
     }
 
     pub fn from_instruction_second(ins: u16) -> Option<Self> {
-        Self::from_u8(((ins&0xe00) >> 9) as u8)
+        Self::from_u8(((ins & 0xe00) >> 9) as u8)
     }
 
     pub fn as_mask_third(&self) -> u16 {
-        (*self as u16)&0x7
+        (*self as u16) & 0x7
     }
 
     pub fn from_instruction_third(ins: u16) -> Option<Self> {
-        Self::from_u8((ins&0x7) as u8)
+        Self::from_u8((ins & 0x7) as u8)
     }
 }
 

--- a/src/register.rs
+++ b/src/register.rs
@@ -32,6 +32,30 @@ impl Register {
             _ => None,
         }
     }
+
+    pub fn as_mask_first(&self) -> u16 {
+        ((self as u16)&0x7) << 12
+    }
+
+    pub fn from_instruction_first(ins: u16) -> Option<Self> {
+        Self::from_u8(((ins&0x7000)>>12) as u8)
+    }
+
+    pub fn as_mask_second(&self) -> u16 {
+        ((self as u16)&0x7) << 9
+    }
+
+    pub fn from_instruction_second(ins: u16) -> Option<Self> {
+        Self::from_u8(((ins&0xe00) >> 9) as u8)
+    }
+
+    pub fn as_mask_third(&self) -> u16 {
+        (self as u16)&0x7
+    }
+
+    pub fn from_instruction_third(ins: u16) -> Option<Self> {
+        Self::from_u8((ins&0x7) as u8)
+    }
 }
 
 impl fmt::Display for Register {

--- a/src/register.rs
+++ b/src/register.rs
@@ -34,7 +34,7 @@ impl Register {
     }
 
     pub fn as_mask_first(&self) -> u16 {
-        ((self as u16)&0x7) << 12
+        ((*self as u16)&0x7) << 12
     }
 
     pub fn from_instruction_first(ins: u16) -> Option<Self> {
@@ -42,7 +42,7 @@ impl Register {
     }
 
     pub fn as_mask_second(&self) -> u16 {
-        ((self as u16)&0x7) << 9
+        ((*self as u16)&0x7) << 9
     }
 
     pub fn from_instruction_second(ins: u16) -> Option<Self> {
@@ -50,7 +50,7 @@ impl Register {
     }
 
     pub fn as_mask_third(&self) -> u16 {
-        (self as u16)&0x7
+        (*self as u16)&0x7
     }
 
     pub fn from_instruction_third(ins: u16) -> Option<Self> {

--- a/src/register.rs
+++ b/src/register.rs
@@ -8,6 +8,7 @@ pub enum RegisterFlag {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Register {
+    Zero,
     A,
     B,
     C,
@@ -15,7 +16,6 @@ pub enum Register {
     SP,
     PC,
     BP,
-    FLAGS,
 }
 
 impl Register {
@@ -28,7 +28,7 @@ impl Register {
             x if x == Register::SP as u8 => Some(Register::SP),
             x if x == Register::PC as u8 => Some(Register::PC),
             x if x == Register::BP as u8 => Some(Register::BP),
-            x if x == Register::FLAGS as u8 => Some(Register::FLAGS),
+            x if x == Register::Zero as u8 => Some(Register::Zero),
             _ => None,
         }
     }
@@ -68,7 +68,7 @@ impl fmt::Display for Register {
             Self::SP => write!(f, "SP"),
             Self::BP => write!(f, "BP"),
             Self::PC => write!(f, "PC"),
-            Self::FLAGS => write!(f, "FLAGS"),
+            Self::Zero => write!(f, "Zero"),
         }
     }
 }
@@ -84,7 +84,7 @@ impl FromStr for Register {
             "SP" => Ok(Register::SP),
             "BP" => Ok(Register::BP),
             "PC" => Ok(Register::PC),
-            "FLAGS" => Ok(Register::FLAGS),
+            "Zero" => Ok(Register::Zero),
             _ => Err(format!("unknown register {}", s)),
         }
     }
@@ -96,13 +96,13 @@ mod test {
 
     #[test]
     fn test_encoding() {
-        assert_eq!(Register::A as u16, 0);
-        assert_eq!(Register::B as u16, 1);
-        assert_eq!(Register::C as u16, 2);
-        assert_eq!(Register::M as u16, 3);
-        assert_eq!(Register::SP as u16, 4);
-        assert_eq!(Register::PC as u16, 5);
-        assert_eq!(Register::BP as u16, 6);
-        assert_eq!(Register::FLAGS as u16, 7);
+        assert_eq!(Register::Zero as u16, 0);
+        assert_eq!(Register::A as u16, 1);
+        assert_eq!(Register::B as u16, 2);
+        assert_eq!(Register::C as u16, 3);
+        assert_eq!(Register::M as u16, 4);
+        assert_eq!(Register::SP as u16, 5);
+        assert_eq!(Register::PC as u16, 6);
+        assert_eq!(Register::BP as u16, 7);
     }
 }

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 use std::str::FromStr;
 
-pub enum RegisterFlag {
+#[repr(u16)]
+pub enum Flag {
     Compare = 0x1,
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -168,6 +168,10 @@ SP: {} | PC: {} | BP: {}",
                     false => Err(format!("failed to write word {} @ {}", self.get_register(r2), addr)),
                 }
             }
+            Instruction::Jump(b) => {
+                self.set_register(Register::PC, self.get_register(Register::PC) + b.value);
+                Ok(())
+            }
             Instruction::System(Register::Zero, reg_arg, signal) => {
                 let sig_fn = self
                     .signal_handlers

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -88,6 +88,37 @@ FLAGS: {:X}",
         let op = Instruction::try_from(instruction)?;
         println!("running {}", op);
         match op {
+            Instruction::Imm(reg, value) => {
+                self.registers[reg as usize] = value;
+                Ok(())
+            },
+            Instruction::Add(r0, r1, dst) => {
+                let a = self.registers[r0 as usize];
+                let b = self.registers[r1 as usize];
+                self.registers[dst as usize] = a+b;
+                Ok(())
+            },
+            Instruction::Sub(r0, r1, dst) => {
+                let a = self.registers[r0 as usize];
+                let b = self.registers[r1 as usize];
+                self.registers[dst as usize] = a-b;
+                Ok(())
+            },
+            Instruction::AddImm(r, i) => {
+                self.registers[r as usize] += i.value as u16;
+                Ok(())
+            }
+            Instruction::AddImmSigned(r, i) => {
+                let raw_register_value = self.registers[r as usize];
+                let imm_signed = i.as_signed();
+                unsafe {
+                    let register_signed: i16 = std::mem::transmute(raw_register_value);
+                    self.registers[r as usize] = std::mem::transmute(register_signed + (imm_signed as i16));
+                }
+                Ok(())
+            }
+
+
             /*
             Instruction::Push(v) => self.push(v.into()),
             Instruction::PopRegister(r) => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -136,6 +136,21 @@ SP: {} | PC: {} | BP: {}",
                 }
                 Ok(())
             }
+            Instruction::ShiftLeft(r0, r1, offset) => {
+                let base = self.get_register(r0);
+                self.set_register(r1, base<<offset.value);
+                Ok(())
+            }
+            Instruction::ShiftRightLogical(r0, r1, offset) => {
+                let base = self.get_register(r0);
+                self.set_register(r1, base>>offset.value);
+                Ok(())
+            }
+            Instruction::ShiftRightArithmetic(r0, r1, offset) => {
+                let base = self.get_register(r0);
+                self.set_register(r1, base>>offset.value);
+                Ok(())
+            }
             Instruction::System(Register::Zero, reg_arg, signal) => {
                 let sig_fn = self
                     .signal_handlers
@@ -158,7 +173,9 @@ SP: {} | PC: {} | BP: {}",
                         .ok_or(format!("unknown signal: 0x{:X}", sig_value))?;
                     sig_fn(self, arg.value as u16)
                 }
-            } /*
+            } 
+
+            /*
               Instruction::Push(v) => self.push(v.into()),
               Instruction::PopRegister(r) => {
                   let value = self.pop()?;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -34,6 +34,13 @@ impl Machine {
         }
     }
 
+    pub fn reset(&mut self) {
+        self.memory.zero_all(); 
+        self.registers = [0; 8];
+        self.flags = 0;
+        self.halt = false;
+    }
+
     pub fn state(&self) -> String {
         format!(
             "A: {} | B: {} | C: {} | M: {}
@@ -132,7 +139,7 @@ Flags: {:016b}",
             Instruction::Sub(r0, r1, dst) => {
                 let a = self.get_register(r0);
                 let b = self.get_register(r1);
-                self.set_register(dst, a - b);
+                self.set_register(dst, a.wrapping_sub(b));
                 Ok(())
             }
             Instruction::AddImm(r, i) => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -13,13 +13,22 @@ pub struct Machine {
     pub memory: Box<dyn Addressable>,
 }
 
-impl Machine {
-    pub fn new() -> Self {
+impl Default for Machine {
+    fn default() -> Self {
         Self {
             registers: [0; 8],
             signal_handlers: HashMap::new(),
             halt: false,
             memory: Box::new(LinearMemory::new(8 * 1024)),
+        }
+    }
+}
+
+impl Machine {
+    pub fn new(memory_words: usize) -> Self {
+        Self {
+            memory: Box::new(LinearMemory::new(2*memory_words)),
+            ..Self::default()
         }
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -37,7 +37,8 @@ impl Machine {
     pub fn state(&self) -> String {
         format!(
             "A: {} | B: {} | C: {} | M: {}
-SP: {} | PC: {} | BP: {}",
+SP: {} | PC: {} | BP: {}
+Flags: {:016b}",
             self.get_register(Register::A),
             self.get_register(Register::B),
             self.get_register(Register::C),
@@ -45,6 +46,7 @@ SP: {} | PC: {} | BP: {}",
             self.get_register(Register::SP),
             self.get_register(Register::PC),
             self.get_register(Register::BP),
+            self.flags,
         )
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -71,7 +71,7 @@ FLAGS: {:X}",
     }
 
     fn set_flag(&mut self, flag: RegisterFlag) {
-        self.registers[Register::FLAGS as usize] |= (flag as u16);
+        self.registers[Register::FLAGS as usize] |= flag as u16;
     }
 
     fn test_flag(&self, flag: RegisterFlag) -> bool {
@@ -88,7 +88,7 @@ FLAGS: {:X}",
         let op = Instruction::try_from(instruction)?;
         println!("running {}", op);
         match op {
-            Instruction::Nop => Ok(()),
+            /*
             Instruction::Push(v) => self.push(v.into()),
             Instruction::PopRegister(r) => {
                 let value = self.pop()?;
@@ -197,6 +197,7 @@ FLAGS: {:X}",
                     .ok_or(format!("unknown signal: 0x{:X}", signal))?;
                 sig_fn(self)
             }
+            */
         }
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -117,6 +117,13 @@ FLAGS: {:X}",
                 }
                 Ok(())
             }
+            Instruction::System(_r0, _r1, signal) => {
+                let sig_fn = self
+                    .signal_handlers
+                    .get(&signal.value)
+                    .ok_or(format!("unknown signal: 0x{:X}", signal.value))?;
+                sig_fn(self)
+            }
 
 
             /*
@@ -221,14 +228,7 @@ FLAGS: {:X}",
                 }
                 Ok(())
             }
-            Instruction::Signal(signal) => {
-                let sig_fn = self
-                    .signal_handlers
-                    .get(&signal)
-                    .ok_or(format!("unknown signal: 0x{:X}", signal))?;
-                sig_fn(self)
-            }
-            */
+                        */
         }
     }
 }

--- a/tests/arith.rs
+++ b/tests/arith.rs
@@ -1,0 +1,65 @@
+
+use simplevm::*;
+use simplevm::Instruction::*;
+use simplevm::Register::*;
+
+
+const SIGHALT: u8 = 0x1;
+
+fn signal_halt(vm: &mut Machine, _: u16) -> Result<(), String> {
+    vm.halt = true;
+    Ok(())
+}
+
+fn run(m: &mut Machine, program: &[Instruction]) -> Result<(), String> {
+    let program_words: Vec<_> = program.iter().map(|x| x.encode_u16()).collect();
+    unsafe {
+        let program_bytes = program_words.align_to::<u8>().1;
+        m.memory.load_from_vec(&program_bytes, 0);
+    }
+    m.set_register(Register::SP, 0x1000);
+    m.define_handler(SIGHALT, signal_halt);
+    while !m.halt {
+        m.step()?;
+    }
+    Ok(())
+}
+
+#[test]
+fn test_add() -> Result<(), String> {
+    let mut vm = Machine::new(1024*4);
+    vm.reset();
+    run(&mut vm, &[
+        Imm(A, 11),
+        Imm(B, 15),
+        Add(A, B, C),
+        System(Zero, Zero, Nibble::new(SIGHALT)),
+    ])?;
+    assert!(vm.get_register(C) == 26, "expected {}, C == {}", 26, vm.get_register(C));
+    Ok(())
+}
+
+#[test]
+fn test_sub() -> Result<(), String> {
+    let mut vm = Machine::new(1024*4);
+    vm.reset();
+    run(&mut vm, &[
+        Imm(A, 20),
+        Imm(B, 15),
+        Sub(A, B, C),
+        System(Zero, Zero, Nibble::new(SIGHALT)),
+    ])?;
+    assert!(vm.get_register(C) == 5, "expected {}, C == {}", 5, vm.get_register(C));
+
+    vm.reset();
+    run(&mut vm, &[
+        Imm(A, 10),
+        Imm(B, 52),
+        Sub(A, B, C),
+        System(Zero, Zero, Nibble::new(SIGHALT)),
+    ])?;
+    assert!(vm.get_register(C) == u16::MAX - 41, "expected {}, C == {}", u16::MAX - 41, vm.get_register(C));
+
+    Ok(())
+   
+}


### PR DESCRIPTION
The old ISA was a bit too simplistic, I've refactored it into a cleaner, smarter ISA.

There is a large change to the macro codegen here, it now works on the fields of each variant rather than taking a set of fields as a whole. Eg before it would know what to do when matching
```
["Register", "Register"]
```
However we now match each field with its index. We know that `(Register, 0)` is masked in a certain way, as is `(Register, 1)` etc. Some components such as a `Nibble` or `Literal7Bit` always appears in the same place, so ordering is not important but there is a quiet implication that there can only be 1 of these (and that we do not create instructions with overlapping masked fields!). This is a pretty fragile aspect to this new macro system, it relies of knowledge of how parts of an instruction are encoded. But it will make adding a new instruction extremely fast/easy. This is the tradeoff I have taken.

A bit of misc cleanup snuck in here. I don't think it's worth rebasing out of here into different branches. I'll just merge this large change soon and try to have better hygiene as I tackle smaller/more contained tasks!