### PR TITLE
Support WASM build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,11 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+crate-type = ["cdylib", "lib"]
+
 [dependencies]
+wasm-bindgen = "0.2"
 
 [[bin]]
 name = "vm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen = "0.2"
 
 [[bin]]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+
+wasm:
+	wasm-pack build --out-dir www/pkg --no-pack --no-typescript --target=web
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,6 @@ pub mod vm;
 pub use crate::op::*;
 pub use crate::register::*;
 pub use crate::vm::*;
+
+#[cfg(target_family = "wasm")]
+pub mod wasm;

--- a/src/op.rs
+++ b/src/op.rs
@@ -25,6 +25,7 @@ use std::str::FromStr;
  * 1000 0000 0000 0000
  */
 
+#[derive(Debug)]
 pub enum InstructionParseError {
     NoContent,
     Fail(String),

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,101 @@
+
+use std::str::FromStr;
+
+use wasm_bindgen::prelude::*;
+use crate::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: String);
+
+    #[wasm_bindgen(js_namespace = console, js_name = log)]
+    fn log_u16(v: u16);
+}
+
+fn signal_write(_: &mut Machine, v: u16) -> Result<(), String> {
+    log_u16(v); 
+    Ok(())
+}
+
+fn signal_halt(m: &mut Machine, _: u16) -> Result<(), String> {
+    m.halt = true;
+    Ok(())
+}
+
+#[wasm_bindgen(js_name = VM)]
+struct JSMachine {
+    m: Machine,
+    tick_rate: f32,
+    tick_acc: f32,
+}
+
+#[wasm_bindgen(js_class = VM)]
+impl JSMachine {
+    #[wasm_bindgen(constructor)]
+    pub fn new(memory_size: usize) -> Self {
+        let mut m = Machine::new(memory_size);
+        m.halt = true;
+        m.define_handler(0xf0, signal_halt);
+        m.define_handler(0x1, signal_write);
+        Self {
+            m,
+            tick_rate: 0.1,
+            tick_acc: 0.0,
+        }
+    }
+
+    #[wasm_bindgen]
+    pub fn write_program(&mut self, b: &[u8]) -> Result<(), String> {
+        let _ = self.m.memory.load_from_vec(b, 0);
+        Ok(())
+    }
+
+    #[wasm_bindgen]
+    pub fn reset(&mut self) {
+        self.m.reset();
+    }
+
+    #[wasm_bindgen]
+    pub fn set_halt(&mut self, b: bool) {
+        self.m.halt = b;
+    }
+
+    #[wasm_bindgen]
+    pub fn set_register(&mut self, register_name: &str, value: u16) -> Result<(), String> {
+        let register = Register::from_str(register_name)?;
+        self.m.set_register(register, value);
+        Ok(())
+    }
+
+    #[wasm_bindgen]
+    pub fn get_register(&self, register_name: &str) -> Result<u16, String> {
+        let register = Register::from_str(register_name)?;
+        Ok(self.m.get_register(register))
+    }
+
+    #[wasm_bindgen]
+    pub fn tick(&mut self, dt: f32) -> Result<(), String> {
+        if self.m.halt {
+            return Ok(());
+        }
+        self.tick_acc += dt;
+        if self.tick_acc > self.tick_rate {
+            self.tick_acc -= self.tick_rate;
+            self.m.step()?;
+        }
+        Ok(())
+    }
+
+    #[wasm_bindgen]
+    pub fn state(&self) -> String {
+        self.m.state() 
+    }
+}
+
+#[wasm_bindgen]
+pub fn assemble_line(line: &str) -> Result<u16, String> {
+    let ins = Instruction::from_str(line).map_err(|x| format!("failed to parse: {:?}", x))?;
+    Ok(ins.encode_u16())
+}
+

--- a/www/index.html
+++ b/www/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+    <title>tom's simple vm</title>
+  </head>
+  <body>
+    <textarea id="program" cols=80 rows=20>
+Imm B 5
+System Zero B 1
+Imm A $f0
+System A A 0
+    </textarea>
+    <button id="compile" text="Compile">Compile</button>
+    <div id="state"></div>
+    <script type="module">
+      import init, { VM, assemble_line } from "./pkg/simplevm.js";
+      init().then(() => {
+        window.VM = VM;
+        window.assemble_line = assemble_line;
+        let vm = new VM(1024);
+        vm.set_register("A", 13);
+        console.log(vm.get_register("A"));
+
+        const programText = document.querySelector("#program");
+        document.querySelector("#compile").onclick = () => {
+          const lines = programText.value.split("\n");
+          const program = [];
+          for (let i in lines) {
+            const line = lines[i].trim();
+            if (line.length == 0 || line[0] == "#") {
+              continue;
+            }
+            const v = assemble_line(line);
+            program.push(v&0xff);
+            program.push((v&0xff00)>>8);
+          }
+          const pp = new Uint8Array(program);
+          vm.reset();
+          vm.write_program(pp);
+          vm.set_halt(false);
+        }
+
+        const uiContainer = document.createElement("pre");
+        document.querySelector("#state").appendChild(uiContainer);
+        let then = performance.now();
+        const loop = (now) => {
+          requestAnimationFrame(loop);
+          let dt = now - then;
+          try {
+            vm.tick(dt);
+          } catch (e) {
+            console.error(e);
+            vm.set_halt(true); 
+          }
+          uiContainer.innerText = vm.state();
+          then = now;
+        };
+        loop(performance.now());
+      });
+    </script>
+  </body>
+</html>
+


### PR DESCRIPTION
Add WASM bindings for manipulating the VM. These are higher level than the Rust bindings, eg using Strings for Register names instead of exporting an enum (or closest JS equivalent).

Currently barebones, but easy to extend in the future now it's there.